### PR TITLE
Keys in credentials & button to generate keypair

### DIFF
--- a/vapid-configuration.html
+++ b/vapid-configuration.html
@@ -3,13 +3,63 @@
         category: 'config',
         defaults: {
             subject: { value: "", required: true },
-            publicKey: { value: "", required: true },
-            privateKey: { value: "", required: true },
+            // The below 3 key fields are not used anymore (i.e. replaced by credentials) but we cannot
+            // remove them here, otherwise the keys of old existing nodes would be lost ...
+            publicKey: { value: ""},
+            privateKey: { value: ""},
             gcmApiKey: { value: "" },
             name: { value: "" }
         },
+        credentials: {
+            // TODO how make credentials required??
+            publicKey2: {type:"password"},
+            privateKey2: {type: "password"},
+            gcmApiKey2: {type:"password"}
+        },
         label: function () {
             return this.name || this.subject;
+        },
+        oneditprepare: function () {
+            var node = this;
+            
+            // For old nodes (without credentials), the (unsecure) keys should be converted to credentials.  Some remarks:
+            // - The old html screen elements should remain available, in order to keep the old node values.
+            // - The new keys have postfix '2', otherwise Node-RED binds the html screen element to both old and new node fields.
+            // - We will manipulate the html screen element values, so Node-RED will automatically sync the node values (at 'Done' or 'Cancel').
+            if (node.publicKey) {
+                $('#node-config-input-publicKey').val("");
+                $('#node-config-input-publicKey2').val(node.publicKey);
+            }
+            if (node.privateKey) {
+                $('#node-config-input-privateKey').val("");
+                $('#node-config-input-privateKey2').val(node.privateKey);
+            }
+            if (node.gcmApiKey) {
+                $('#node-config-input-gcmApiKey').val("");
+                $('#node-config-input-gcmApiKey2').val(node.gcmApiKey);
+            }
+        
+            $("#node-input-generateKeyPair").click(function () {
+                if ($("#node-config-input-publicKey2").val() || $("#node-config-input-privateKey2").val()) {
+                    if (!confirm("The current keypair will be overwritten!  Are you sure to continue?")) {
+                        // The user has clicked the 'Cancel' button
+                        return;
+                    }
+                }
+                
+                // Ask the server side flow to generate a new key pair
+                $.getJSON('vapid_configuration/generate_key_pair', function(jsonData) {
+                    // Show the new keys on the config screen
+                    $("#node-config-input-publicKey2").val(jsonData.publicKey);
+                    $("#node-config-input-privateKey2").val(jsonData.privateKey);
+                    
+                    // Make sure the validators are being triggerd, otherwise the red border will remain around the input fields
+                    $("#node-config-input-publicKey2").change();
+                    $("#node-config-input-privateKey2").change();
+                }).error(function() {
+                    RED.notify("Cannot create VAPID key pair.  See Node-RED log for more details...", "error");
+                });
+            });
         }
     });
 
@@ -21,16 +71,26 @@
         <input type="text" id="node-config-input-subject" placeholder="This must be either a URL or a 'mailto:' address.">
     </div>
     <div class="form-row">
-        <label for="node-config-input-publicKey"><i class="icon-tag"></i> Public Key</label>
-        <input type="text" id="node-config-input-publicKey" placeholder="The public VAPID key">
+        <label>&nbsp;</label>
+        <button id="node-input-generateKeyPair"><i class="fa fa-exchange"></i> Generate VAPID keypair</button>
+    </div>
+    <div class="form-row" hidden>
+        <!-- Unused hidden fields to bind the old (unsecure) keys in the node instance -->
+        <input type="text" id="node-config-input-publicKey">
+        <input type="text" id="node-config-input-privateKey">
+        <input type="text" id="node-config-input-gcmApiKey">
     </div>
     <div class="form-row">
-        <label for="node-config-input-privateKey"><i class="icon-tag"></i> Private Key</label>
-        <input type="text" id="node-config-input-privateKey" placeholder="The public VAPID key">
+        <label for="node-config-input-publicKey2"><i class="icon-tag"></i> Public Key</label>
+        <input type="password" id="node-config-input-publicKey2">
     </div>
     <div class="form-row">
-        <label for="node-config-input-gcmApiKey"><i class="icon-tag"></i> GCM API Key (for older browsers)</label>
-        <input type="text" id="node-config-input-gcmApiKey" placeholder="The API key to send with the GCM request">
+        <label for="node-config-input-privateKey2"><i class="icon-tag"></i> Private Key</label>
+        <input type="password" id="node-config-input-privateKey2">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-gcmApiKey2"><i class="icon-tag"></i> GCM API Key (for older browsers)</label>
+        <input type="password" id="node-config-input-gcmApiKey2">
     </div>
     <div class="form-row">
         <label for="node-config-input-name"><i class="icon-tag"></i> Name</label>

--- a/vapid-configuration.js
+++ b/vapid-configuration.js
@@ -1,10 +1,51 @@
 module.exports = function (RED) {
+  const webpush = require('web-push');
+    
   function VapidConfigurationNode (config) {
     RED.nodes.createNode(this, config)
     this.subject = config.subject
+    // Keep the old key fields, to support old nodes (without credentials)
     this.publicKey = config.publicKey
     this.privateKey = config.privateKey
     this.gcmApiKey = config.gcmApiKey
+    
+    var node = this;
+    
+    // Allow other nodes to access the secure node private credentials.
+    // This is not good practice, but don't see a better approach since these nodes were designed originally without credentials ...
+    this.getKeys = function () {
+        // Use the new keys in the credentials, unless we are dealing with an old node (without credentials)
+        return {
+            publicKey : node.credentials.publicKey2  || node.publicKey,
+            privateKey: node.credentials.privateKey2 || node.privateKey,
+            gcmApiKey : node.credentials.gcmApiKey2  || node.gcmApiKey
+        }
+    }
   }
-  RED.nodes.registerType('vapid-configuration', VapidConfigurationNode)
+  
+  RED.nodes.registerType("vapid-configuration", VapidConfigurationNode,{
+    credentials: {
+      publicKey2: {type: "password"},
+      privateKey2: {type: "password"},
+      gcmApiKey2: {type: "password"}
+    }
+  });
+  
+  // Make the key pair generation available to the config screen (in the flow editor)
+  RED.httpAdmin.get('/vapid_configuration/generate_key_pair', RED.auth.needsPermission('vapid-configuration.write'), async function(req, res){
+    try {
+      // Generate a VAPID keypair
+      const vapidKeys = webpush.generateVAPIDKeys();
+ 
+      // Return public key and private key to the config screen (since they need to be stored in the node's credentials)
+      res.json({
+        publicKey: vapidKeys.publicKey,
+        privateKey: vapidKeys.privateKey
+      })
+    }
+    catch (err) {
+      console.log("Error while generating VAPID keypair: " + err)
+      res.status(500).json({error: 'Error while generating VAPID keypair'})
+    }
+  });
 }

--- a/web-push.js
+++ b/web-push.js
@@ -16,16 +16,19 @@ module.exports = function (RED) {
 
         let options
         if (node.vapidConfiguration) {
+          // Get the secure keys from the VAPID configuration credentials
+          var keys = node.vapidConfiguration.getKeys();
+          
           options = {
             vapidDetails: {
               subject: node.vapidConfiguration.subject,
-              publicKey: node.vapidConfiguration.publicKey,
-              privateKey: node.vapidConfiguration.privateKey
+              publicKey: keys.publicKey,
+              privateKey: keys.privateKey
             }
           }
 
-          if (node.vapidConfiguration.gcmApiKey) {
-            options['gcmAPIKey'] = node.vapidConfiguration.gcmApiKey
+          if (keys.gcmApiKey) {
+            options['gcmAPIKey'] = keys.gcmApiKey
           }
         }
 


### PR DESCRIPTION
Hey Maxim,

Here are some of the changes I contacted you about.
Unfortunately a few months later than expected ...

+ A http endpoint is added on the backend to generate a keypair, and a button has been added to the frontend to call the endpoint.
+ The 3 keys aren't anymore plain text fields, but are now converted to Node-RED credential fields.  

## Button to generate keypair
To avoid the users having to use command line stuff, I have added a button to generate a keypair:

![demo_button](https://user-images.githubusercontent.com/14224149/73592245-709ae900-44f8-11ea-968d-5e9553b0f7dd.gif)

Some remark:
+ The confirmation popup is only displayed when one of both fields already contains something.
+ The endpoint has been secured by ```needsPermission```.  So only users specified in the settings.js file (with write permissions) will have access to the endpoint.  Although not really necessary, since anybody is allowed to generate a new keypair ...

## Keys in credentials
Until now the 3 key fields were plain text fields, which has some disadvantages:
+ When you export a part of your flow (to share with others), your key fields will also be exported.
+ The keys are visible to everybody that has access to the flow editor.
+ The keys are stored in the flow.json file as plain text.
+ The keys will be transferred over and over again between client and server.
+ The keys will be readable by all other (malicious) nodes.
+ ...

To solve that, every Node-RED node has a '**credentials**' section where I'm going to store the keys.
The major part of the work was to migrate the plain-text keys of old existing nodes to the new keys in the credentials, to make sure we have no impact on existing flows:
1. I had to keep both the old html elements and the old node fields, otherwise Node-RED messed up the old values behind my back.   The new fields have a postfix ```"2```.
1. As soon as you enter the keys manually (or via the new generation button), the keys will be temporarily be available in the browser:

   ![image](https://user-images.githubusercontent.com/14224149/73599511-92ba5880-4544-11ea-9dd9-8b951a1a90ac.png)

1. But once you have deployed the flow, the keys are only available on the server.  From then on Node-RED will only send to the browser whether the key fields have content or not:

   ![image](https://user-images.githubusercontent.com/14224149/73592424-9f19c380-44fa-11ea-934a-060be9e52249.png)

   So this is much better compared to passing the keys all the time between client and server ...

1. As long as we keep using input fields of type 'text' you would see indeed that Node-RED only sends dummy text content to fill the html fields:

   ![image](https://user-images.githubusercontent.com/14224149/73599287-09a22200-4542-11ea-9e3e-6a78b9df498d.png)

1. Therefore we will change the input fields to type "password", to display the dummy text like this:

   ![image](https://user-images.githubusercontent.com/14224149/73599301-2b9ba480-4542-11ea-8a00-bcec19b93880.png)

Should be much secure now...

But there is something that is still not correct ;-(
Node-RED makes sure that nodes can only read their own credentials, so other nodes cannot access them!  However the keys from your config node are also needed in your web-push node.  This means I had to add a new function to the config node, to get access to the keys:
```
this.getKeys = function () {
        return {
            publicKey : node.credentials.publicKey2  || node.publicKey,
            privateKey: node.credentials.privateKey2 || node.privateKey,
            gcmApiKey : node.credentials.gcmApiKey2  || node.gcmApiKey
        }
 }
```
And that function is now called from the web-push node.  _**But this means that all other nodes can call it to read the keys, which is NOT secure!!**_

Would be better if the config node had following two functions:
+ A ```getPublicKey``` function (which I have to call from my new dashboard UI web push node).
+ A ```sendNotification``` function which contains a part of the code of your web-push node.  That is the only way to ensure that the private key is only known to the config node...

Do you have any thoughts about this?  We can also start continuing with this pull-request, and afterwards fix this issue ...

P.S. when there are no subscriptions, an _**error**_ was logged.  However since it is very likely that there are no subscriptions at some moment in time, I have changed it to _**warning**_:

![image](https://user-images.githubusercontent.com/14224149/73599411-8d104300-4543-11ea-9e14-65aa37a79db5.png)
![image](https://user-images.githubusercontent.com/14224149/73599414-939eba80-4543-11ea-9b2f-63dcc8465fb4.png)

Is that ok for you?
 
Thanks a lot for reviewing this pull request !!!
Bart