### PR TITLE
Improved logging

### DIFF
--- a/web-push.js
+++ b/web-push.js
@@ -41,6 +41,25 @@ module.exports = function (RED) {
                   }
                 })
               }).catch((err) => {
+                // When a standard error text has been received, make sure it is converted to mimic a WebPushError object.
+                // Otherwise it has no 'failed' property, so it will be considered no failure further on ...
+                if (err instanceof Error) {
+                  err = {
+                    failed: {
+                      name: err.name,
+                      message: "Standard exception",
+                      body: err.message
+                    }
+                  }
+                }
+                
+                // Remove some properties from the WebPushError to make sure the logs only contain useful information
+                delete err.failed.headers
+                delete err.failed.endpoint
+
+                // Log the error message to simplify troubleshooting
+                node.error(JSON.stringify(err.failed))
+
                 resolve({
                   failed: JSON.parse(JSON.stringify(err))
                 })


### PR DESCRIPTION
Hi @webmaxru,

Our users are struggling to troubleshoot about what is going on in case of a failed notification.
I hope that this pull request can improve this problem a bit.

This pull request solves two different issues.  But I created a single pull request, since both issues occur in the same catch handler.

Thanks for reviewing!!
Bart

## 1. Handle standard Error objects
When you e.g. change your VAPID keys to an invalid value (e.g. by adding "xxxx" to it), we will catch a standard Error object (i.e. with a stack trace) instead of a WebPushError object:

![image](https://user-images.githubusercontent.com/14224149/131246201-43f50d7c-ed30-4b25-84de-c89e7fa549ee.png)

Since such an exception instance has no "failed" property, it will considered as succesfull.  So the node status will show "1 send, 0 failed" which is incorrect.

To solve that, I convert the Error exception to a WebPushError:

![image](https://user-images.githubusercontent.com/14224149/131246256-a626d67f-7114-4ffb-b31a-5d364e7642e4.png)

P.S. of course I don't have all the information (statuscode, headers...) that would have been in a normal WebPushError object, but that those extra properties aren't used anyway ...

## 2. Log the errors in Node-RED
Via `node.error` I report now the errors to Node-RED, so they appear in the Debug sidebar:

![image](https://user-images.githubusercontent.com/14224149/131246331-42c5a52b-e5a6-4432-8323-f58034eaccc6.png)

That way it is e.g. possible to handle those errors via a Catch-node, and report the problem somehow.

P.S. I remove some fields (headers, ...) to avoid a long cryptic log, with information that is not useful in most cases anyway...



